### PR TITLE
[JENKINS-73185] Split Action for sidepanel from actual content

### DIFF
--- a/src/main/java/io/jenkins/plugins/peopleview/AsynchPeople.java
+++ b/src/main/java/io/jenkins/plugins/peopleview/AsynchPeople.java
@@ -27,7 +27,6 @@ package io.jenkins.plugins.peopleview;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
-import hudson.model.Action;
 import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -59,7 +58,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
-public class AsynchPeople extends ProgressiveRendering implements Action {
+public class AsynchPeople extends ProgressiveRendering {
 
     private final Collection<TopLevelItem> items;
     private final User unknown;
@@ -67,21 +66,6 @@ public class AsynchPeople extends ProgressiveRendering implements Action {
     private final Set<User> modified = new HashSet<>();
     private final String iconSize;
     public final ModelObject parent;
-
-    @Override
-    public String getIconFileName() {
-        return "symbol-people";
-    }
-
-    @Override
-    public String getDisplayName() {
-        return Messages.People_DisplayName();
-    }
-
-    @Override
-    public String getUrlName() {
-        return "asynchPeople";
-    }
 
     public AsynchPeople(Jenkins parent) {
         this.parent = parent;

--- a/src/main/java/io/jenkins/plugins/peopleview/AsynchPeopleAction.java
+++ b/src/main/java/io/jenkins/plugins/peopleview/AsynchPeopleAction.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.peopleview;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Action;
+import hudson.model.View;
+import java.util.Objects;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerProxy;
+
+public class AsynchPeopleAction implements Action, StaplerProxy {
+
+    private final View view;
+    private final Jenkins jenkins;
+
+    public AsynchPeopleAction(@NonNull View v) {
+        this.view = v;
+        this.jenkins = null;
+    }
+
+    public AsynchPeopleAction(@NonNull Jenkins j) {
+        this.view = null;
+        this.jenkins = j;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return "symbol-people";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.People_DisplayName();
+    }
+
+    @Override
+    public String getUrlName() {
+        return "asynchPeople";
+    }
+
+    @Override
+    public Object getTarget() {
+        if (view == null) {
+            return new AsynchPeople(Objects.requireNonNull(jenkins));
+        }
+        return new AsynchPeople(view);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/peopleview/People.java
+++ b/src/main/java/io/jenkins/plugins/peopleview/People.java
@@ -25,7 +25,6 @@
 
 package io.jenkins.plugins.peopleview;
 
-import hudson.model.Action;
 import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -47,22 +46,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 @ExportedBean
-public class People implements Action {
-    @Override
-    public String getUrlName() {
-        return "people";
-    }
-
-    @Override
-    public String getDisplayName() {
-        return Messages.People_DisplayName();
-    }
-
-    @Override
-    public String getIconFileName() {
-        return null; // no sidepanel link
-    }
-
+public class People {
     @Exported
     public final List<UserInfo> users;
 

--- a/src/main/java/io/jenkins/plugins/peopleview/PeopleAction.java
+++ b/src/main/java/io/jenkins/plugins/peopleview/PeopleAction.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.peopleview;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Action;
+import hudson.model.View;
+import java.util.Objects;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerProxy;
+
+public class PeopleAction implements Action, StaplerProxy {
+
+    private final View view;
+    private final Jenkins jenkins;
+
+    public PeopleAction(@NonNull View v) {
+        this.view = v;
+        this.jenkins = null;
+    }
+
+    public PeopleAction(@NonNull Jenkins j) {
+        this.view = null;
+        this.jenkins = j;
+    }
+
+    @Override
+    public String getUrlName() {
+        return "people";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.People_DisplayName();
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null; // no sidepanel link
+    }
+
+    @Override
+    public Object getTarget() {
+        if (view == null) {
+            return new People(Objects.requireNonNull(jenkins));
+        }
+        return new People(view);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/peopleview/TransientFactory.java
+++ b/src/main/java/io/jenkins/plugins/peopleview/TransientFactory.java
@@ -40,8 +40,8 @@ public class TransientFactory extends TransientViewActionFactory {
         final Jenkins j = Jenkins.get();
         if (j.equals(v.getOwner()) && v instanceof AllView) {
             // If this is the top-level (~not in a folder) AllView, show everything
-            return List.of(new People(j), new AsynchPeople((j)));
+            return List.of(new PeopleAction(j), new AsynchPeopleAction(j));
         }
-        return List.of(new People(v), new AsynchPeople(v));
+        return List.of(new PeopleAction(v), new AsynchPeopleAction(v));
     }
 }


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-73185

The `People` constructor can be very expensive as it iterates over all objects to populate the fields. Between 1.0 making `People` an `Action`, and it being constantly instantiated by the `TransientActionFactory`, that's a lot of work done constantly.

This splits the `Action` (to render the sidepanel) from the actual content.

### Testing done

Added log statements in constructors, only the `AsynchPeople` API causes `People` instantiation (plus accessing `People` directly).

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
